### PR TITLE
Add support to run openshift must-gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Tool to help diagonize issues with OpenShift clusters. It does it by:
 - capturing prometheus DB from the running prometheus pods to local file system. This can be used to look at the metrics later by running prometheus locally with the backed up DB.
+- Capturing openshift cluster information including  all the operator managed components using https://github.com/openshift/must-gather.
 
 ## Run
 ```
@@ -10,9 +11,21 @@ Edit env.sh according to the needs and run the ocp_diagnosis script:
 $ source env.sh; ./ocp_diagnosis.sh
 
 options supported:
-	 OUTPUT_DIR=str,                       str=dir to store the capture prometheus data
-	 PROMETHEUS_CAPTURE=str,               str=true or false, enables/disables prometheus capture
-	 PROMETHEUS_CAPTURE_TYPE=str,          str=wal or full, wal captures the write ahead log and full captures the entire prometheus DB
+	OUTPUT_DIR=str,                       str=dir to store the capture prometheus data
+	PROMETHEUS_CAPTURE=str,               str=true or false, enables/disables prometheus capture
+	PROMETHEUS_CAPTURE_TYPE=str,          str=wal or full, wal captures the write ahead log and full captures the entire prometheus DB
+	OPENSHIFT_MUST_GATHER=str,            str=true or false, gathers cluster data including information about all the operator managed components
+	STORAGE_MODE=str,                     str=pbench, moves the results to the pbench results dir to be shipped to the pbench server in case the tool is run using pbench
+```
+
+### Pbench server for storage
+[Pbench](https://github.com/distributed-system-analysis/pbench.git) does a great job in terms of both collection and long term storage. The tool currently supports pbench as the storage mode instead of just storing the results on the local file system, we will be adding support to store results in Amazon S3 in the future.
+
+In order to use pbench as the storage, the tool needs to be run using pbench and STORAGE_MODE should be set to pbench:
+
+```
+$ source env.sh; pbench-user-benchmark --sysinfo=none ocp_diagnosis.sh
+# pbench-move-results --prefix ocp-diagnosis-$(date +"%Y%m%d-%H%M%S")
 ```
 
 ## Visualize the captured data locally on prometheus server

--- a/env.sh
+++ b/env.sh
@@ -4,3 +4,4 @@ export OUTPUT_DIR=/root
 export PROMETHEUS_CAPTURE=true
 export PROMETHEUS_CAPTURE_TYPE=wal
 export OPENSHIFT_MUST_GATHER=true
+export STORAGE_MODE=pbench

--- a/ocp_diagnosis.sh
+++ b/ocp_diagnosis.sh
@@ -12,6 +12,8 @@ function help() {
 	printf "\t OUTPUT_DIR=str,                       str=dir to store the capture prometheus data\n"
 	printf "\t PROMETHEUS_CAPTURE=str,               str=true or false, enables/disables prometheus capture\n"
 	printf "\t PROMETHEUS_CAPTURE_TYPE=str,          str=wal or full, wal captures the write ahead log and full captures the entire prometheus DB\n"
+	printf "\t OPENSHIFT_MUST_GATHER=str,            str=true or false, gathers cluster data including information about all the operator managed components\n"
+	printf "\t STORAGE_MODE=str,                     str=pbench, moves the results to the pbench results dir to be shipped to the pbench server in case the tool is run using pbench\n"
 }
 
 echo "==========================================================================="
@@ -36,6 +38,15 @@ if [[ -z "$PROMETHEUS_CAPTURE_TYPE" ]]; then
 	exit 1
 fi
 
+if [[ -z "$OPENSHIFT_MUST_GATHER" ]]; then
+	echo "Looks like OPENSHIFT_MUST_GATHER is not defined, please check"
+	help
+	exit 1
+fi
+
+if [[ -z "$STORAGE_MODE" ]]; then
+	echo "Looke like STORAGE_MODE is not defined, storing the results on local file system"
+fi
 
 # Check for kubeconfig
 if [[ -z $KUBECONFIG ]] && [[ ! -s $HOME/.kube/config ]]; then
@@ -56,6 +67,19 @@ fi
 # pick a prometheus pod
 prometheus_pod=$(oc get pods -n $prometheus_namespace | grep -w "Running" | awk -F " " '/prometheus-k8s/{print $1}' | tail -n1)
 
+# get the timestamp
+ts=$(date +"%Y%m%d-%H%M%S")
+
+# set the output_dir to pbench results dir
+if [[ "$STORAGE_MODE" == "pbench" ]]; then
+	echo "Detected sotrage mode as $STORAGE_MODE"
+	echo "Assuming that the ocp diagnosis tool is run using pbench-user-benchmark"
+	echo "Fetching the latest pbench results dir"
+	result_dir="/var/lib/pbench-agent/$(ls -t /var/lib/pbench-agent/ | grep "pbench-user" | head -1)"/1/reference-result
+        echo "Copying the collected data to $result_dir"
+        export OUTPUT_DIR="/var/lib/pbench-agent/$(ls -t /var/lib/pbench-agent/ | grep "pbench-user" | head -1)"/1
+fi
+
 # copy the prometheus write ahead log from the prometheus pod
 function capture_wal() {
 	echo "================================================================================="
@@ -63,7 +87,7 @@ function capture_wal() {
 	echo "================================================================================="
 	oc cp $prometheus_namespace/$prometheus_pod:/prometheus/wal -c prometheus $OUTPUT_DIR/wal/
 	echo "creating a tarball of the captured DB at $OUTPUT_DIR"
-	XZ_OPT=--threads=0 tar cJf $OUTPUT_DIR/prometheus.tar.xz $OUTPUT_DIR/wal
+	XZ_OPT=--threads=0 tar cJf $OUTPUT_DIR/prometheus-$ts.tar.xz $OUTPUT_DIR/wal
 	if [[ $? == 0 ]]; then
 		rm -rf wal
 	fi
@@ -76,12 +100,20 @@ function capture_full_db() {
 	echo "================================================================================="
 	oc cp  $prometheus_namespace/$prometheus_pod:/prometheus/ -c prometheus $OUTPUT_DIR/data/
 	echo "creating a tarball of the captured DB at $OUTPUT_DIR"
-	XZ_OPT=--threads=0 tar cJf $OUTPUT_DIR/prometheus.tar.xz -C $OUTPUT_DIR/data .
+	XZ_OPT=--threads=0 tar cJf $OUTPUT_DIR/prometheus-$ts.tar.xz -C $OUTPUT_DIR/data .
 	if [[ $? == 0 ]]; then
 		rm -rf data
 	fi
 }
 
+function must_gather() {
+	echo "================================================================================="
+	echo "                     Running OpenShift must-gather                               "
+	echo "================================================================================="
+	echo "Asssuming the oc client on the host supports collecting must-gather"
+	oc adm must-gather --dest-dir=$OUTPUT_DIR/must-gather-$ts
+}
+	
 if [[ "$PROMETHEUS_CAPTURE" == "true" ]]; then
 	if [[ "$PROMETHEUS_CAPTURE_TYPE" == "wal" ]]; then
 		capture_wal
@@ -91,4 +123,8 @@ if [[ "$PROMETHEUS_CAPTURE" == "true" ]]; then
 		echo "Looks like $type is not a valid option, please check"
 		help
 	fi
+fi
+
+if [[ "$OPENSHIFT_MUST_GATHER" == "true" ]]; then
+	must_gather
 fi


### PR DESCRIPTION
This commit:
- Enables capturing cluster information including all the operator
   managed components using https://github.com/openshift/must-gather.
- Adds support to use pbench server for long term storage.