### PR TITLE
Better defaults for capturing prom db

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 export OUTPUT_DIR=/root
+# Captures prometheus database when enabled
 export PROMETHEUS_CAPTURE=true
-export PROMETHEUS_CAPTURE_TYPE=wal
+# Options available: wal or full, wal captures the write ahead log while full captures the entire prometheus DB
+export PROMETHEUS_CAPTURE_TYPE=full
+# Captures must-gather when enabled
 export OPENSHIFT_MUST_GATHER=true
-export STORAGE_MODE=pbench
-
+# Stores the tar balls on the local filesystem when empty, other options available are pbench and snappy server
+export STORAGE_MODE=


### PR DESCRIPTION
This commit modifies the script to capture the full prometheus
database instead of wal by default and stores it on local filesystem.